### PR TITLE
Support flareact config file

### DIFF
--- a/configs/loaders.js
+++ b/configs/loaders.js
@@ -1,0 +1,15 @@
+module.exports = function ({ dev, isServer }) {
+  return {
+    babel: {
+      loader: "babel-loader",
+      options: {
+        presets: ["@babel/preset-env", "@babel/preset-react"],
+        plugins: [
+          "react-require",
+          "@babel/plugin-transform-runtime",
+          Boolean(dev && !isServer) && require.resolve("react-refresh/babel"),
+        ].filter(Boolean),
+      },
+    },
+  };
+};

--- a/configs/utils.js
+++ b/configs/utils.js
@@ -1,0 +1,14 @@
+const path = require("path");
+const fs = require("fs");
+
+function fileExistsInDir(dir, file) {
+  return fs.existsSync(path.join(dir, file));
+}
+
+module.exports.fileExistsInDir = fileExistsInDir;
+
+module.exports.flareactConfig = function (dir) {
+  const file = "flareact.config.js";
+
+  return fileExistsInDir(dir, file) ? require(path.join(dir, file)) : {};
+};

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -1,14 +1,12 @@
 const path = require("path");
-const fs = require("fs");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const DEV = !!process.env.WORKER_DEV || process.env.NODE_ENV === "development";
+const defaultLoaders = require("./loaders");
+const { fileExistsInDir } = require("./utils");
 
-function fileExistsInCwd(file) {
-  return fs.existsSync(path.join(process.cwd(), file));
-}
+module.exports = function ({ dev, isServer }) {
+  const loaders = defaultLoaders({ dev, isServer });
 
-module.exports = {
-  baseConfig: {
+  return {
     context: process.cwd(),
     plugins: [new MiniCssExtractPlugin()],
     stats: "errors-warnings",
@@ -17,18 +15,12 @@ module.exports = {
         {
           test: /\.js$/,
           exclude: /node_modules\/(?!(flareact)\/).*/,
-          use: {
-            loader: "babel-loader",
-            options: {
-              presets: ["@babel/preset-env", "@babel/preset-react"],
-              plugins: ["react-require", "@babel/plugin-transform-runtime"],
-            },
-          },
+          use: loaders.babel,
         },
         {
           test: /\.css$/,
           use: [
-            DEV
+            dev
               ? "style-loader"
               : {
                   loader: MiniCssExtractPlugin.loader,
@@ -41,7 +33,7 @@ module.exports = {
               loader: "postcss-loader",
               options: {
                 config: {
-                  path: fileExistsInCwd("postcss.config.js")
+                  path: fileExistsInDir(process.cwd(), "postcss.config.js")
                     ? process.cwd()
                     : path.resolve(__dirname),
                 },
@@ -51,5 +43,5 @@ module.exports = {
         },
       ],
     },
-  },
+  };
 };

--- a/src/bin/flareact.js
+++ b/src/bin/flareact.js
@@ -18,7 +18,10 @@ if (command === "dev") {
 
   concurrently(
     [
-      { command: "WORKER_DEV=true wrangler dev", name: "wrangler" },
+      {
+        command: "WORKER_DEV=true IS_WORKER=true wrangler dev",
+        name: "worker",
+      },
       {
         command:
           "NODE_ENV=development webpack-dev-server --config node_modules/flareact/configs/webpack.client.config.js --mode development",
@@ -45,7 +48,7 @@ if (command === "publish") {
     [
       {
         command:
-          "webpack --config node_modules/flareact/configs/webpack.client.config.js --out ./out --mode production && wrangler publish",
+          "NODE_ENV=production webpack --config node_modules/flareact/configs/webpack.client.config.js --out ./out --mode production && IS_WORKER=true wrangler publish",
         name: "publish",
       },
     ],


### PR DESCRIPTION
Adds support for a top-level `flareact.config.js` file which replaces the original `webpack.config.js`.

Users can pass custom webpack config [similar to Next.js](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config).