### PR TITLE
Prefetch and preload pages

### DIFF
--- a/src/client/page-loader.js
+++ b/src/client/page-loader.js
@@ -47,15 +47,23 @@ export default class PageLoader {
       if (!this.loadingRoutes[route]) {
         this.loadingRoutes[route] = true;
 
-        const prefix = dev ? "pages" : "_flareact/static/pages";
+        const url = getPagePathUrl(route);
 
-        this.loadScript(prefix + route + `.js`);
+        this.loadScript(url);
       }
     });
   }
 
   prefetchData(route) {
     const url = getPagePropsUrl(route);
+
+    this.loadPrefetch(url, "script");
+  }
+
+  prefetch(route) {
+    const url = getPagePathUrl(route);
+
+    if (connectionIsSlow()) return;
 
     this.loadPrefetch(url, "script");
   }
@@ -96,6 +104,12 @@ export function getPagePropsUrl(pagePath) {
   return `/_flareact/props${pagePath}.json`;
 }
 
+function getPagePathUrl(pagePath) {
+  const prefix = dev ? "pages" : "_flareact/static/pages";
+
+  return prefix + pagePath + ".js";
+}
+
 /**
  * Borrowed from Next.js
  */
@@ -117,3 +131,19 @@ const relPrefetch =
     : // https://caniuse.com/#feat=link-rel-prefetch
       // IE 11, Edge 12+, nearly all evergreen
       "prefetch";
+
+/**
+ * Borrowed from Next.js.
+ * Don't prefetch if using 2G or if Save-Data is enabled.
+ *
+ * https://github.com/GoogleChromeLabs/quicklink/blob/453a661fa1fa940e2d2e044452398e38c67a98fb/src/index.mjs#L115-L118
+ * License: Apache 2.0
+ */
+function connectionIsSlow() {
+  let cn;
+  if ((cn = navigator.connection)) {
+    return cn.saveData || /2g/.test(cn.effectiveType);
+  }
+
+  return false;
+}

--- a/src/client/page-loader.js
+++ b/src/client/page-loader.js
@@ -54,6 +54,12 @@ export default class PageLoader {
     });
   }
 
+  prefetchData(route) {
+    const url = getPagePropsUrl(route);
+
+    this.loadPrefetch(url, "script");
+  }
+
   loadScript(path) {
     const prefix =
       process.env.NODE_ENV === "production" ? "/" : "http://localhost:8080/";
@@ -65,4 +71,49 @@ export default class PageLoader {
     script.src = url;
     document.body.appendChild(script);
   }
+
+  loadPrefetch(path, as) {
+    return new Promise((resolve, reject) => {
+      if (
+        document.querySelector(`link[rel="${relPrefetch}"][href^="${path}"]`)
+      ) {
+        return resolve();
+      }
+
+      const link = document.createElement("link");
+      link.rel = relPrefetch;
+      link.href = path;
+      link.as = as;
+      link.onload = resolve;
+      link.onerror = reject;
+
+      document.head.appendChild(link);
+    });
+  }
 }
+
+export function getPagePropsUrl(pagePath) {
+  return `/_flareact/props${pagePath}.json`;
+}
+
+/**
+ * Borrowed from Next.js
+ */
+function hasRel(rel, link) {
+  try {
+    link = document.createElement("link");
+    return link.relList.supports(rel);
+  } catch {}
+}
+
+/**
+ * Borrowed from Next.js
+ */
+const relPrefetch =
+  hasRel("preload") && !hasRel("prefetch")
+    ? // https://caniuse.com/#feat=link-rel-preload
+      // macOS and iOS (Safari does not support prefetch)
+      "preload"
+    : // https://caniuse.com/#feat=link-rel-prefetch
+      // IE 11, Edge 12+, nearly all evergreen
+      "prefetch";

--- a/src/client/page-loader.js
+++ b/src/client/page-loader.js
@@ -54,6 +54,12 @@ export default class PageLoader {
     });
   }
 
+  async loadPageProps(pagePath) {
+    const url = getPagePropsUrl(pagePath);
+    const res = await fetch(url);
+    return await res.json();
+  }
+
   prefetchData(route) {
     const url = getPagePropsUrl(route);
 

--- a/src/link.js
+++ b/src/link.js
@@ -1,19 +1,7 @@
 import React, { Children } from "react";
 import { useRouter } from "./router";
 
-/**
- * Detects whether a given url is from the same origin as the current page (browser only).
- */
-function isLocal(url) {
-  const locationOrigin = getLocationOrigin();
-  const resolved = new URL(url, locationOrigin);
-  return resolved.origin === locationOrigin;
-}
-
-function getLocationOrigin() {
-  const { protocol, hostname, port } = window.location;
-  return `${protocol}//${hostname}${port ? ":" + port : ""}`;
-}
+let prefetched = {};
 
 /**
  * Heavily-inspired by next/link
@@ -25,6 +13,8 @@ export default function Link(props) {
   const child = Children.only(props.children);
 
   const { href, as } = props;
+
+  const shouldPrefetch = props.prefetch !== false;
 
   function linkClicked(e) {
     const { nodeName, target } = e.currentTarget;
@@ -69,6 +59,16 @@ export default function Link(props) {
     },
   };
 
+  if (shouldPrefetch) {
+    childProps.onMouseEnter = (e) => {
+      if (child.props && typeof child.props.onMouseEnter === "function") {
+        child.props.onMouseEnter(e);
+      }
+
+      prefetch(router, href, as, { priority: true });
+    };
+  }
+
   // If child is an <a> tag and doesn't have a href attribute, or if the 'passHref' property is
   // defined, we specify the current 'href', so that repetition is not needed by the user
   if (props.passHref || (child.type === "a" && !("href" in child.props))) {
@@ -76,4 +76,26 @@ export default function Link(props) {
   }
 
   return React.cloneElement(child, childProps);
+}
+
+/**
+ * Detects whether a given url is from the same origin as the current page (browser only).
+ */
+function isLocal(url) {
+  const locationOrigin = getLocationOrigin();
+  const resolved = new URL(url, locationOrigin);
+  return resolved.origin === locationOrigin;
+}
+
+function getLocationOrigin() {
+  const { protocol, hostname, port } = window.location;
+  return `${protocol}//${hostname}${port ? ":" + port : ""}`;
+}
+
+function prefetch(router, href, as, options) {
+  if (typeof window === "undefined") return;
+
+  router.prefetch(href, as, options);
+
+  prefetched[href + "%" + as] = true;
 }

--- a/src/link.js
+++ b/src/link.js
@@ -1,7 +1,9 @@
-import React, { Children } from "react";
+import React, { Children, useEffect, useState } from "react";
 import { useRouter } from "./router";
 
 let prefetched = {};
+let cachedIntersectionObserver;
+let listeners = new Map();
 
 /**
  * Heavily-inspired by next/link
@@ -10,11 +12,29 @@ let prefetched = {};
  */
 export default function Link(props) {
   const router = useRouter();
+  const [childElm, setChildElm] = useState();
   const child = Children.only(props.children);
 
   const { href, as } = props;
 
   const shouldPrefetch = props.prefetch !== false;
+
+  useEffect(() => {
+    if (
+      shouldPrefetch &&
+      IntersectionObserver &&
+      childElm &&
+      childElm.tagName
+    ) {
+      const isPrefetched = prefetched[href + "%" + as];
+
+      if (!isPrefetched) {
+        return listenToIntersections(childElm, () => {
+          prefetch(router, href, as);
+        });
+      }
+    }
+  }, [shouldPrefetch, childElm, href, as, router]);
 
   function linkClicked(e) {
     const { nodeName, target } = e.currentTarget;
@@ -40,6 +60,8 @@ export default function Link(props) {
   const childProps = {
     // Forward ref if the user has it set
     ref: (el) => {
+      if (el) setChildElm(el);
+
       if (child && child.ref) {
         if (typeof child.ref === "function") child.ref(el);
         else if (typeof child.ref === "object") {
@@ -98,4 +120,46 @@ function prefetch(router, href, as, options) {
   router.prefetch(href, as, options);
 
   prefetched[href + "%" + as] = true;
+}
+
+function getObserver() {
+  if (cachedIntersectionObserver) return cachedIntersectionObserver;
+
+  if (!IntersectionObserver) return undefined;
+
+  return (cachedIntersectionObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!listeners.has(entry.target)) return;
+
+        const cb = listeners.get(entry.target);
+        if (entry.isIntersecting || entry.intersectionRatio > 0) {
+          cachedIntersectionObserver.unobserve(entry.target);
+          listeners.delete(entry.target);
+          cb();
+        }
+      });
+    },
+    {
+      rootMargin: "200px",
+    }
+  ));
+}
+
+function listenToIntersections(el, cb) {
+  const observer = getObserver();
+
+  if (!observer) return () => {};
+
+  observer.observe(el);
+  listeners.set(el, cb);
+
+  return () => {
+    try {
+      observer.unobserve(el);
+    } catch (e) {
+      console.error(e);
+    }
+    listeners.delete(el);
+  };
 }

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
+import { getPagePropsUrl } from "./client/page-loader";
 
 const RouterContext = React.createContext();
 
@@ -62,15 +63,19 @@ export function RouterProvider({
     window.history.pushState({ href, asPath }, null, asPath);
   }
 
-  function prefetch(href) {
+  function prefetch(href, as) {
     const pagePath = normalizePathname(href);
+    const asPath = normalizePathname(as || href);
 
     if (process.env.NODE_ENV !== "production") {
       return;
     }
 
-    // TODO: Support `prefetch` in addition to `loadPage`
-    pageLoader.loadPage(pagePath);
+    return Promise.all([
+      pageLoader.prefetchData(asPath),
+      // TODO: Support `prefetch` in addition to `loadPage`
+      pageLoader.loadPage(pagePath),
+    ]);
   }
 
   useEffect(() => {
@@ -119,7 +124,8 @@ export function useRouter() {
 }
 
 async function loadPageProps(pagePath) {
-  const res = await fetch(`/_flareact/props${pagePath}.json`);
+  const url = getPagePropsUrl(pagePath);
+  const res = await fetch(url);
   return await res.json();
 }
 

--- a/src/router.js
+++ b/src/router.js
@@ -31,7 +31,7 @@ export function RouterProvider({
 
       if (!pageCache[normalizedAsPath]) {
         const page = await pageLoader.loadPage(pagePath);
-        const { pageProps } = await loadPageProps(normalizedAsPath);
+        const { pageProps } = await pageLoader.loadPageProps(normalizedAsPath);
 
         pageCache[normalizedAsPath] = {
           Component: page,
@@ -120,12 +120,6 @@ export function RouterProvider({
 
 export function useRouter() {
   return useContext(RouterContext);
-}
-
-async function loadPageProps(pagePath) {
-  const url = getPagePropsUrl(pagePath);
-  const res = await fetch(url);
-  return await res.json();
 }
 
 export function normalizePathname(pathname) {

--- a/src/router.js
+++ b/src/router.js
@@ -62,6 +62,13 @@ export function RouterProvider({
     window.history.pushState({ href, asPath }, null, asPath);
   }
 
+  function prefetch(href) {
+    const pagePath = normalizePathname(href);
+
+    // TODO: Support `prefetch` in addition to `loadPage`
+    pageLoader.loadPage(pagePath);
+  }
+
   useEffect(() => {
     function handlePopState(e) {
       let newRoute = {};
@@ -95,6 +102,7 @@ export function RouterProvider({
     pathname: route.href,
     asPath: route.asPath,
     push,
+    prefetch,
   };
 
   return (

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,4 @@
 import React, { useContext, useState, useEffect } from "react";
-import { getPagePropsUrl } from "./client/page-loader";
 
 const RouterContext = React.createContext();
 

--- a/src/router.js
+++ b/src/router.js
@@ -65,6 +65,10 @@ export function RouterProvider({
   function prefetch(href) {
     const pagePath = normalizePathname(href);
 
+    if (process.env.NODE_ENV !== "production") {
+      return;
+    }
+
     // TODO: Support `prefetch` in addition to `loadPage`
     pageLoader.loadPage(pagePath);
   }

--- a/src/router.js
+++ b/src/router.js
@@ -63,18 +63,17 @@ export function RouterProvider({
     window.history.pushState({ href, asPath }, null, asPath);
   }
 
-  function prefetch(href, as) {
-    const pagePath = normalizePathname(href);
-    const asPath = normalizePathname(as || href);
-
+  function prefetch(href, as, { priority } = {}) {
     if (process.env.NODE_ENV !== "production") {
       return;
     }
 
+    const pagePath = normalizePathname(href);
+    const asPath = normalizePathname(as || href);
+
     return Promise.all([
       pageLoader.prefetchData(asPath),
-      // TODO: Support `prefetch` in addition to `loadPage`
-      pageLoader.loadPage(pagePath),
+      pageLoader[priority ? "loadPage" : "prefetch"](pagePath),
     ]);
   }
 


### PR DESCRIPTION
This PR takes a major step toward being production-ready by implementing **prefetching** and **preloading** based on various circumstances:

- When the user hovers over a `<Link>`, the page script tag and the page props JSON are loaded
- Any `<Link>` elements within 200px of the viewport are automatically `prefetch`ed as `<link>` tags in the `<head>`.

This is mirrored from the incredible work Next.js has done to lay this foundation.