### PR TITLE
Implement Page Manifest

### DIFF
--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -98,10 +98,19 @@ module.exports = (env, argv) => {
             },
           }
         : {
+            /**
+             * N.B. most of this is borrowed from Next.js source code. I've tried to comment
+             * my understanding of each item below, but I'm sure there's much to be desired.
+             */
             chunks: "all",
             cacheGroups: {
               default: false,
               vendors: false,
+              /**
+               * First, grab the "normal" things: react, etc from node_modules. These will
+               * for sure be in *every* component, so we might as well pull this out and make
+               * it cacheable.
+               */
               framework: {
                 chunks: "all",
                 name: "framework",
@@ -111,7 +120,11 @@ module.exports = (env, argv) => {
                 // becoming a part of the commons chunk)
                 enforce: true,
               },
-              // TODO: Write comments for what each chunk does
+              /**
+               * OK - we've got the framework out of the way. Next, we're going to pull out any LARGE
+               * modules (> 160kb) that happen to be used in an entrypoint from node_modules. Even if
+               * it's only used by a single chunk - don't care.
+               */
               lib: {
                 test(module) {
                   return (
@@ -139,11 +152,19 @@ module.exports = (env, argv) => {
                 minChunks: 1,
                 reuseExistingChunk: true,
               },
+              /**
+               * Next, commons. I guess if *every single page* uses some of this code, this chunk is generated.
+               * I'm not sure exactly what this would be, or why we care to split it out here instead of e.g. `shared`.
+               */
               commons: {
                 name: "commons",
                 minChunks: totalPages,
                 priority: 20,
               },
+              /**
+               * Here's another chunk. Not sure what the difference is between this and our pal `commons`. I guess this is
+               * reserved for less-common chunks, used by at least two other chunks.
+               */
               shared: {
                 name(module, chunks) {
                   return (

--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -8,13 +8,14 @@ const defaultLoaders = require("./loaders");
 const webpack = require("webpack");
 const TerserJSPlugin = require("terser-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const glob = require("glob");
+const BuildManifestPlugin = require("./webpack/plugins/build-manifest-plugin");
+const crypto = require("crypto");
 
 const projectDir = process.cwd();
 const flareact = flareactConfig(projectDir);
 const dev = process.env.NODE_ENV === "development";
 const isServer = false;
-
-const glob = require("glob");
 
 const pageManifest = glob.sync("./pages/**/*.js");
 
@@ -53,8 +54,21 @@ if (!entry["pages/_app"]) {
   entry["pages/_app"] = pageLoader;
 }
 
-const totalPages = Object.keys(entry).filter((key) => key.includes("pages"))
-  .length;
+const totalPages = Object.keys(entry).filter(
+  (key) => key.includes("pages") && !/pages\/api\//.test(key)
+).length;
+
+// TODO: Revisit
+const isModuleCSS = (module) => {
+  return (
+    // mini-css-extract-plugin
+    module.type === `css/mini-extract` ||
+    // extract-css-chunks-webpack-plugin (old)
+    module.type === `css/extract-chunks` ||
+    // extract-css-chunks-webpack-plugin (new)
+    module.type === `css/extract-css-chunks`
+  );
+};
 
 module.exports = (env, argv) => {
   const config = {
@@ -88,23 +102,68 @@ module.exports = (env, argv) => {
             cacheGroups: {
               default: false,
               vendors: false,
-              styles: {
-                name: "styles",
-                test: /\.css$/,
-                chunks: "all",
-                enforce: true,
-              },
               framework: {
                 chunks: "all",
                 name: "framework",
-                filename: "[name].js",
                 test: /[\\/]node_modules[\\/](react|react-dom|scheduler|prop-types)[\\/]/,
                 priority: 40,
                 // Don't let webpack eliminate this chunk (prevents this chunk from
                 // becoming a part of the commons chunk)
                 enforce: true,
               },
+              // TODO: Write comments for what each chunk does
+              lib: {
+                test(module) {
+                  return (
+                    module.size() > 160000 &&
+                    /node_modules[/\\]/.test(module.identifier())
+                  );
+                },
+                name(module) {
+                  const hash = crypto.createHash("sha1");
+                  if (isModuleCSS(module)) {
+                    module.updateHash(hash);
+                  } else {
+                    if (!module.libIdent) {
+                      throw new Error(
+                        `Encountered unknown module type: ${module.type}. Please open an issue.`
+                      );
+                    }
+
+                    hash.update(module.libIdent({ context: dir }));
+                  }
+
+                  return hash.digest("hex").substring(0, 8);
+                },
+                priority: 30,
+                minChunks: 1,
+                reuseExistingChunk: true,
+              },
+              commons: {
+                name: "commons",
+                minChunks: totalPages,
+                priority: 20,
+              },
+              shared: {
+                name(module, chunks) {
+                  return (
+                    crypto
+                      .createHash("sha1")
+                      .update(
+                        chunks.reduce((acc, chunk) => {
+                          return acc + chunk.name;
+                        }, "")
+                      )
+                      .digest("hex") + (isModuleCSS(module) ? "_CSS" : "")
+                  );
+                },
+                priority: 10,
+                minChunks: 2,
+                reuseExistingChunk: true,
+              },
             },
+            maxInitialRequests: 25,
+            minSize: 20000,
           },
     },
     context: projectDir,
@@ -122,11 +181,7 @@ module.exports = (env, argv) => {
     output: {
       path: path.resolve(projectDir, "out/_flareact/static"),
     },
-    plugins: [
-      new MiniCssExtractPlugin({
-        filename: "[name].css",
-      }),
-    ],
+    plugins: [new MiniCssExtractPlugin(), new BuildManifestPlugin()],
     devServer: {
       contentBase: path.resolve(projectDir, "out"),
       hot: true,

--- a/configs/webpack.worker.config.js
+++ b/configs/webpack.worker.config.js
@@ -5,11 +5,21 @@ const webpack = require("webpack");
 const { flareactConfig } = require("./utils");
 const defaultLoaders = require("./loaders");
 const { nanoid } = require("nanoid");
+const fs = require("fs");
 
 const dev = !!process.env.WORKER_DEV;
 const isServer = true;
 const projectDir = process.cwd();
 const flareact = flareactConfig(projectDir);
+
+const outPath = path.resolve(projectDir, "out");
+
+const buildManifest = dev
+  ? {}
+  : fs.readFileSync(
+      path.join(outPath, "_flareact", "static", "build-manifest.json"),
+      "utf-8"
+    );
 
 module.exports = function (env, argv) {
   let config = {
@@ -22,7 +32,7 @@ module.exports = function (env, argv) {
     new CopyPlugin([
       {
         from: path.resolve(projectDir, "public"),
-        to: path.resolve(projectDir, "out"),
+        to: outPath,
       },
     ])
   );
@@ -33,6 +43,8 @@ module.exports = function (env, argv) {
 
   if (dev) {
     inlineVars.DEV = dev;
+  } else {
+    inlineVars["process.env.BUILD_MANIFEST"] = buildManifest;
   }
 
   config.plugins.push(new webpack.DefinePlugin(inlineVars));

--- a/configs/webpack/plugins/build-manifest-plugin.js
+++ b/configs/webpack/plugins/build-manifest-plugin.js
@@ -1,0 +1,40 @@
+const { RawSource } = require("webpack-sources");
+
+module.exports = class BuildManifestPlugin {
+  createAssets(compilation, assets) {
+    const namedChunks = compilation.namedChunks;
+
+    const assetMap = {
+      pages: {},
+    };
+
+    const mainJsChunk = namedChunks.get("main");
+    const mainJsFiles = [...mainJsChunk.files].filter((file) =>
+      file.endsWith(".js")
+    );
+
+    for (const entrypoint of compilation.entrypoints.values()) {
+      let pagePath = entrypoint.name.match(/^pages[/\\](.*)$/);
+
+      if (!pagePath) continue;
+
+      const pageFiles = [...entrypoint.getFiles()].filter(
+        (file) => file.endsWith(".css") || file.endsWith(".js")
+      );
+
+      assetMap.pages[`/${pagePath[1]}`] = [...mainJsFiles, ...pageFiles];
+    }
+
+    assets["build-manifest.json"] = new RawSource(
+      JSON.stringify(assetMap, null, 2)
+    );
+
+    return assets;
+  }
+
+  apply(compiler) {
+    compiler.hooks.emit.tap("FlareactBuildManifest", (compilation) => {
+      this.createAssets(compilation, compilation.assets);
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
-    "webpack-merge": "^5.1.1"
+    "webpack-merge": "^5.1.1",
+    "webpack-sources": "^1.4.3"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",

--- a/src/components/_document.js
+++ b/src/components/_document.js
@@ -77,6 +77,7 @@ export function FlareactScripts({ initialData, page, buildManifest }) {
       `pages${page}.js`,
     ].forEach((script) => scripts.add(script));
   } else {
+    buildManifest.helpers.forEach((script) => scripts.add(script));
     buildManifest.pages["/_app"]
       .filter((script) => script.endsWith(".js"))
       .forEach((script) => scripts.add(script));

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -10,6 +10,8 @@ const dev =
   (typeof DEV !== "undefined" && !!DEV) ||
   process.env.NODE_ENV !== "production";
 
+const buildManifest = dev ? {} : process.env.BUILD_MANIFEST;
+
 export async function handleRequest(event, context, fallback) {
   const url = new URL(event.request.url);
   const { pathname } = url;
@@ -83,6 +85,7 @@ export async function handleRequest(event, context, fallback) {
             helmet={helmet}
             page={page}
             context={context}
+            buildManifest={buildManifest}
           />
         );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,7 +3583,7 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5288,7 +5288,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6641,11 +6641,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6654,32 +6649,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6725,11 +6698,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
- Adds a `page-manifest.json` generated by the client webpack build
- Allows the worker webpack build to load, stringify as a env var, and pass it to `_document.js`
- Document can then add scripts/styles as needed :tada:
- Also loads `_buildManfest.js` in the client, which is used in `PageLoader` to determine which dependencies need to be loaded/prefetched for a given page

THANK YOU NEXT.JS FOR ALL OF THIS!