### PR TITLE
Cache static assets in the browser

### DIFF
--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -201,6 +201,7 @@ module.exports = (env, argv) => {
     },
     output: {
       path: path.resolve(projectDir, "out/_flareact/static"),
+      chunkFilename: `${dev ? "[name]" : "[name].[contenthash]"}.js`,
     },
     plugins: [new MiniCssExtractPlugin(), new BuildManifestPlugin()],
     devServer: {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -15,12 +15,16 @@ export async function handleEvent(event, context, DEBUG) {
 
   return await handleRequest(event, context, async () => {
     try {
+      options.cacheControl = {
+        // By default, cache static assets for one year
+        browserTTL: 365 * 24 * 60 * 60,
+      };
+
       if (DEBUG) {
         // customize caching
-        options.cacheControl = {
-          bypassCache: true,
-        };
+        options.cacheControl.bypassCache = true;
       }
+
       return await getAssetFromKV(event, options);
     } catch (e) {
       // if an error is thrown try to serve the asset at 404.html


### PR DESCRIPTION
- This adds a content hash (thanks Webpack!) to static assets
- The hash changes whenever the content changes
- This means we can send back `cache-control` headers for the user's browser to cache everything for a year by default 🎉 