### PR TITLE
Query enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+    "@testing-library/react": "^11.1.0",
     "babel-jest": "^26.2.2",
     "jest": "^26.2.2",
     "react": "^16.13.1",

--- a/src/client/page-loader.js
+++ b/src/client/page-loader.js
@@ -145,7 +145,8 @@ export default class PageLoader {
 }
 
 export function getPagePropsUrl(pagePath) {
-  return `/_flareact/props${pagePath}.json`;
+  const [basePath, search] = pagePath.split("?");
+  return `/_flareact/props${basePath}.json${search ? "?" + search : ""}`;
 }
 
 // Used in development only

--- a/src/router.js
+++ b/src/router.js
@@ -1,8 +1,5 @@
 import React, { useContext, useState, useEffect, useMemo } from "react";
-import {
-  convertSearchParamsToQueryObject,
-  extractDynamicParams,
-} from "./utils";
+import { extractDynamicParams } from "./utils";
 import { DYNAMIC_PAGE } from "./worker/pages";
 
 const RouterContext = React.createContext();
@@ -38,11 +35,16 @@ export function RouterProvider({
   }, [route.asPath, route.href]);
 
   const query = useMemo(() => {
+    const url = new URL(
+      window.location.protocol + window.location.host + route.asPath
+    );
+    const queryParams = Object.fromEntries(url.searchParams.entries());
+
     return {
-      ...convertSearchParamsToQueryObject(searchParams),
+      ...queryParams,
       ...params,
     };
-  }, [searchParams, params]);
+  }, [route.asPath, params]);
 
   useEffect(() => {
     async function loadNewPage() {

--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,7 @@ export function RouterProvider({
   initialComponent,
   pageLoader,
 }) {
-  const { pathname: initialPathname, search, searchParams } = new URL(
+  const { protocol, host, pathname: initialPathname, search } = new URL(
     initialUrl
   );
   const [route, setRoute] = useState({
@@ -35,16 +35,14 @@ export function RouterProvider({
   }, [route.asPath, route.href]);
 
   const query = useMemo(() => {
-    const url = new URL(
-      window.location.protocol + window.location.host + route.asPath
-    );
+    const url = new URL(protocol + "//" + host + route.asPath);
     const queryParams = Object.fromEntries(url.searchParams.entries());
 
     return {
       ...queryParams,
       ...params,
     };
-  }, [route.asPath, params]);
+  }, [protocol, host, route.asPath, params]);
 
   useEffect(() => {
     async function loadNewPage() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,5 @@
 import { DYNAMIC_PAGE } from "./worker/pages";
 
-export function convertSearchParamsToQueryObject(searchParams) {
-  return [...searchParams.entries()].reduce((query, [key, value]) => {
-    query[key] = value;
-    return query;
-  }, {});
-}
-
 /**
  * Extract dynamic params from a slug path. For use in the router, but should eventually
  * be refactored to share responsibilities with the /worker/pages.js module.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,38 @@
+import { DYNAMIC_PAGE } from "./worker/pages";
+
+export function convertSearchParamsToQueryObject(searchParams) {
+  return [...searchParams.entries()].reduce((query, [key, value]) => {
+    query[key] = value;
+    return query;
+  }, {});
+}
+
+/**
+ * Extract dynamic params from a slug path. For use in the router, but should eventually
+ * be refactored to share responsibilities with the /worker/pages.js module.
+ *
+ * @param {string} source e.g. /articles/[slug]
+ * @param {string} path   e.g. /articles/hello-world
+ * @returns {<[string]: string>} e.g. { slug: 'hello-world' }
+ */
+export function extractDynamicParams(source, path) {
+  let test = source;
+  let parts = [];
+  let params = {};
+
+  for (const match of source.matchAll(/\[(\w+)\]/g)) {
+    parts.push(match[1]);
+
+    test = test.replace(DYNAMIC_PAGE, () => "([\\w_-]+)");
+  }
+
+  test = new RegExp(test, "g");
+
+  const matches = path.matchAll(test);
+
+  for (const match of matches) {
+    parts.forEach((part, idx) => (params[part] = match[idx + 1]));
+  }
+
+  return params;
+}

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -5,7 +5,6 @@ import { RouterProvider, normalizePathname } from "../router";
 import { getPage, getPageProps, PageNotFoundError } from "./pages";
 import AppProvider from "../components/AppProvider";
 import { Helmet } from "react-helmet";
-import { convertSearchParamsToQueryObject } from "../utils";
 
 const dev =
   (typeof DEV !== "undefined" && !!DEV) ||
@@ -16,7 +15,7 @@ const buildManifest = dev ? {} : process.env.BUILD_MANIFEST;
 export async function handleRequest(event, context, fallback) {
   const url = new URL(event.request.url);
   const { pathname, searchParams } = url;
-  const query = convertSearchParamsToQueryObject(searchParams);
+  const query = Object.fromEntries(searchParams.entries());
 
   if (pathname.startsWith("/_flareact/static")) {
     return await fallback(event);

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -1,6 +1,6 @@
 import App from "../components/_app";
 
-const DYNAMIC_PAGE = new RegExp("\\[(\\w+)\\]", "g");
+export const DYNAMIC_PAGE = new RegExp("\\[(\\w+)\\]", "g");
 
 export function resolvePagePath(pagePath, keys) {
   const pagesMap = keys.map((page) => {
@@ -65,15 +65,20 @@ export function getPage(pagePath, context) {
   }
 }
 
-export async function getPageProps(page) {
+export async function getPageProps(page, query) {
   let pageProps = {};
 
   const params = page.params || {};
 
   const fetcher = page.getEdgeProps || page.getStaticProps;
 
+  const queryObject = {
+    ...query,
+    ...params,
+  };
+
   if (fetcher) {
-    const { props, revalidate } = await fetcher({ params });
+    const { props, revalidate } = await fetcher({ params, query: queryObject });
 
     pageProps = {
       ...props,

--- a/tests/router.spec.js
+++ b/tests/router.spec.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { RouterProvider, useRouter } from "../src/router";
+import { render, screen } from "@testing-library/react";
+
+it("knows basic information about a route", () => {
+  render(
+    <RouterProvider
+      initialUrl="https://demo.workers.dev/hello/world"
+      initialPagePath="/hello/[slug]"
+      initialComponent={Noop}
+    >
+      <RouteTest />
+    </RouterProvider>
+  );
+
+  expect(screen.getByTestId("pathname").innerHTML).toBe("/hello/[slug]");
+  expect(screen.getByTestId("asPath").innerHTML).toBe("/hello/world");
+  expect(screen.getByTestId("query").innerHTML).toBe(
+    JSON.stringify({ slug: "world" })
+  );
+});
+
+function RouteTest() {
+  const router = useRouter();
+
+  return (
+    <div>
+      <p data-testid="pathname">{router.pathname}</p>
+      <p data-testid="asPath">{router.asPath}</p>
+      <p data-testid="query">{JSON.stringify(router.query)}</p>
+    </div>
+  );
+}
+
+function Noop() {
+  return <p>Hi</p>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,21 @@
     "@babel/plugin-transform-react-jsx-source" "^7.10.4"
     "@babel/plugin-transform-react-pure-annotations" "^7.10.4"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz#51b9092befbeeed938335a109dbe0df51451e9dc"
+  integrity sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.11.0", "@babel/runtime@^7.8.4":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
@@ -1196,6 +1211,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
+  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -1429,10 +1455,37 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@testing-library/dom@^7.26.0":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.3.tgz#5554ee985f712d621bd676104b879f85d9a7a0ef"
+  integrity sha512-/1P6taENE/H12TofJaS3L1J28HnXx8ZFhc338+XPR5y1E3g5ttOgu86DsGnV9/n2iPrfJQVUZ8eiGYZGSxculw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.1"
+    lz-string "^1.4.4"
+    pretty-format "^26.4.2"
+
+"@testing-library/react@^11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.1.0.tgz#dfb4b3177d05a8ccf156b5fd14a5550e91d7ebe4"
+  integrity sha512-Nfz58jGzW0tgg3irmTB7sa02JLkLnCk+QN3XG6WiaGQYb0Qc4Ok00aujgjdxlIQWZHbb4Zj5ZOIeE9yKFSs4sA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@testing-library/dom" "^7.26.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
@@ -1505,6 +1558,13 @@
   integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@^7.0.4":
@@ -1963,6 +2023,14 @@ argv-formatter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
   integrity sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2692,7 +2760,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -3206,6 +3274,11 @@ core-js-compat@^3.6.2:
   dependencies:
     browserslist "^4.8.5"
     semver "7.0.0"
+
+core-js-pure@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3808,6 +3881,11 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+dom-accessibility-api@^0.5.1:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-serializer@0:
   version "0.2.2"
@@ -6793,6 +6871,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 macos-release@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
@@ -8935,6 +9018,16 @@ pretty-format@^26.2.0:
   integrity sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==
   dependencies:
     "@jest/types" "^26.2.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.4.2:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.0.tgz#1e1030e3c70e3ac1c568a5fd15627671ea159391"
+  integrity sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==
+  dependencies:
+    "@jest/types" "^26.6.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"


### PR DESCRIPTION
- Exports `query` from the `router` hook object
- Includes both query string params from the URL, but also the params from dynamic page paths
- Passes `query` to `getEdgeProps` in addition to `params`

Fixes #31