### PR TITLE
Fix dynamic indexes

### DIFF
--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -28,6 +28,7 @@ pageManifest.forEach((page) => {
 
   let pageName = page.match(/\/(.+)\.js$/)[1];
 
+  // Flatten any dynamic `index` pages
   if (pageName !== "pages/index" && pageName.endsWith("/index")) {
     pageName = pageName.replace(/\/index$/, "");
   }

--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -26,7 +26,11 @@ let entry = {
 pageManifest.forEach((page) => {
   if (/pages\/api\//.test(page)) return;
 
-  const pageName = page.match(/\/(.+)\.js$/)[1];
+  let pageName = page.match(/\/(.+)\.js$/)[1];
+
+  if (pageName !== "pages/index" && pageName.endsWith("/index")) {
+    pageName = pageName.replace(/\/index$/, "");
+  }
 
   const pageLoaderOpts = {
     page: pageName,

--- a/configs/webpack/plugins/build-manifest-plugin.js
+++ b/configs/webpack/plugins/build-manifest-plugin.js
@@ -23,7 +23,12 @@ module.exports = class BuildManifestPlugin {
         (file) => file.endsWith(".css") || file.endsWith(".js")
       );
 
-      assetMap.pages[`/${pagePath[1]}`] = [...mainJsFiles, ...pageFiles];
+      let pageName = pagePath[1];
+
+      // Flatten any dynamic `index` pages
+      pageName = pageName.replace(/\/index/, "");
+
+      assetMap.pages[`/${pageName}`] = [...mainJsFiles, ...pageFiles];
     }
 
     assets["build-manifest.json"] = new RawSource(

--- a/src/components/_document.js
+++ b/src/components/_document.js
@@ -11,7 +11,12 @@ export default function Document({
 }) {
   const htmlAttrs = helmet.htmlAttributes.toComponent();
   const bodyAttrs = helmet.bodyAttributes.toComponent();
-  const currentPage = page.page.replace(/^\./, "").replace(/\.(js|css)$/, "");
+  let currentPage = page.page.replace(/^\./, "").replace(/\.(js|css)$/, "");
+
+  // Flatten dynamic `index.js` pages
+  if (currentPage !== "/index" && currentPage.endsWith("/index")) {
+    currentPage = currentPage.replace(/\/index$/, "");
+  }
 
   // TODO: Drop all these props into a context and consume them in individual components
   // so this page can be extended.

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -23,15 +23,17 @@ export function resolvePagePath(pagePath, keys) {
       page,
       pagePath: page.replace(/^\./, "").replace(/\.js$/, ""),
       parts,
-      test: new RegExp("^" + test, isDynamic ? "g" : ""),
+      test: new RegExp("^" + test + "$", isDynamic ? "g" : ""),
     };
   });
 
   pagesMap.sort((a) => (a.page.includes("index") ? -1 : 1));
 
-  let page = !pagePath.endsWith("/index")
-    ? pagesMap.find((p) => p.test.test(pagePath + "/index"))
-    : pagesMap.find((p) => p.test.test(pagePath));
+  let page = pagesMap.find((p) => p.test.test(pagePath));
+
+  if (!page) {
+    page = pagesMap.find((p) => p.test.test(pagePath + "/index"));
+  }
 
   if (!page) return null;
   if (!page.parts.length) return page;

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -23,11 +23,15 @@ export function resolvePagePath(pagePath, keys) {
       page,
       pagePath: page.replace(/^\./, "").replace(/\.js$/, ""),
       parts,
-      test: new RegExp(test, isDynamic ? "g" : ""),
+      test: new RegExp("^" + test, isDynamic ? "g" : ""),
     };
   });
 
-  let page = pagesMap.find((p) => p.test.test(pagePath));
+  pagesMap.sort((a) => (a.page.includes("index") ? -1 : 1));
+
+  let page = !pagePath.endsWith("/index")
+    ? pagesMap.find((p) => p.test.test(pagePath + "/index"))
+    : pagesMap.find((p) => p.test.test(pagePath));
 
   if (!page) return null;
   if (!page.parts.length) return page;

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -27,10 +27,18 @@ export function resolvePagePath(pagePath, keys) {
     };
   });
 
+  /**
+   * Sort pages to include those with `index` in the name first, because
+   * we need those to get matched more greedily than their dynamic counterparts.
+   */
   pagesMap.sort((a) => (a.page.includes("index") ? -1 : 1));
 
   let page = pagesMap.find((p) => p.test.test(pagePath));
 
+  /**
+   * If an exact match couldn't be found, try giving it another shot with /index at
+   * the end. This helps discover dynamic nested index pages.
+   */
   if (!page) {
     page = pagesMap.find((p) => p.test.test(pagePath + "/index"));
   }

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -23,6 +23,18 @@ it("matches dynamic pages", () => {
   expect(path.params).toEqual({ slug: "hello" });
 });
 
+it.only("matches dynamic page indexes", () => {
+  const path = resolvePagePath("/posts", [
+    "./index.js",
+    "./apples.js",
+    "./posts/[slug].js",
+    "./posts/index.js",
+  ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/index.js");
+});
+
 it("matches longer dynamic pages", () => {
   const path = resolvePagePath("/posts/hello-world-it-me", [
     "./index.js",

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -23,7 +23,7 @@ it("matches dynamic pages", () => {
   expect(path.params).toEqual({ slug: "hello" });
 });
 
-it.only("matches dynamic page indexes", () => {
+it("matches dynamic page indexes", () => {
   const path = resolvePagePath("/posts", [
     "./index.js",
     "./apples.js",

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -35,6 +35,18 @@ it("matches dynamic page indexes", () => {
   expect(path.page).toBe("./posts/index.js");
 });
 
+it("matches dynamic page indexes matching directory names", () => {
+  const path = resolvePagePath("/posts", [
+    "./index.js",
+    "./apples.js",
+    "./posts/[slug].js",
+    "./posts.js",
+  ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts.js");
+});
+
 it("matches longer dynamic pages", () => {
   const path = resolvePagePath("/posts/hello-world-it-me", [
     "./index.js",


### PR DESCRIPTION
Where one might have the following pages:

```
/index.js
/posts/[slug].js
/posts/index.js
/docs/[slug].js
/docs.js
```

One might expect to be able to visit each of those pages as:

```
/
/posts/hello-world
/posts
/docs/doc-one
/docs
```

This PR does that.

Fixes #32 