### PR TITLE
Automatically cast primitive data into Response objects

### DIFF
--- a/docs/api-routes.md
+++ b/docs/api-routes.md
@@ -14,6 +14,24 @@ export default async (event) => {
 
 For an API route to work, you need to export a default function (a **request handler**) which receives a [`FetchEvent` parameter](https://developers.cloudflare.com/workers/reference/apis/fetch-event).
 
-Your API method must return a new instance of [`Response`](https://developers.cloudflare.com/workers/reference/apis/response/).
+Your API method may return a new instance of [`Response`](https://developers.cloudflare.com/workers/reference/apis/response/). This allows you to customize headers, formatting, and status code.
+
+However, Flareact will conveniently wrap your API method's response in a `Response` object if you return only a primitive:
+
+```js
+export default async (event) => {
+  return { hello: "world" };
+};
+
+// becomes:
+// new Response(JSON.stringify({ hello: 'world' }), { headers: { 'content-type': 'application/json' }})
+
+export default async (event) => {
+  return "Hello, world";
+};
+
+// becomes:
+// new Response('Hello, world')
+```
 
 API routes handle requests exactly like [standard Cloudflare Worker requests](https://developers.cloudflare.com/workers/about/how-it-works/), except that you **do not need to call `event.respondWith`**.

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -50,7 +50,21 @@ export async function handleRequest(event, context, fallback) {
 
     if (pageIsApi(normalizedPathname)) {
       const page = getPage(normalizedPathname, context);
-      return await page.default(event);
+      const response = await page.default(event);
+
+      if (response instanceof Object && !(response instanceof Response)) {
+        return new Response(JSON.stringify(response), {
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+      }
+
+      if (!(response instanceof Response)) {
+        return new Response(response);
+      }
+
+      return response;
     }
 
     return await handleCachedPageRequest(


### PR DESCRIPTION
This is a neat convenience mechanism so you don't have to be as verbose in your API methods.