### PR TITLE
Add TypeScript example & docs

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,38 @@
+# TypeScript Support
+
+Flareact supports TypeScript out of the box (**currently in `alpha`**.
+
+To get started, add `typescript` to your project:
+
+```bash
+yarn add flareact@alpha typescript
+yarn add -D @types/react
+```
+
+Then you can write components in TypeScript:
+
+```tsx
+type IndexProps = {
+  message: string;
+};
+
+export async function getEdgeProps() {
+  return {
+    props: {
+      message: "Hello",
+    } as IndexProps,
+  };
+}
+
+export default function Index({ message }: IndexProps) {
+  return (
+    <div>
+      <p>{message}</p>
+    </div>
+  );
+}
+```
+
+Coming soon:
+
+- Official Flareact type definitions

--- a/examples/with-typescript/.gitignore
+++ b/examples/with-typescript/.gitignore
@@ -1,0 +1,28 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+/out/
+
+# production
+/dist/
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env
+
+/worker

--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -1,0 +1,1 @@
+# Flareact TypeScript Example

--- a/examples/with-typescript/index.js
+++ b/examples/with-typescript/index.js
@@ -1,0 +1,27 @@
+import { handleEvent } from "flareact";
+
+/**
+ * The DEBUG flag will do two things that help during development:
+ * 1. we will skip caching on the edge, which makes it easier to
+ *    debug.
+ * 2. we will return an error message on exception in your Response rather
+ *    than the default 404.html page.
+ */
+const DEBUG = false;
+
+addEventListener("fetch", (event) => {
+  try {
+    event.respondWith(
+      handleEvent(event, require.context("./pages/", true, /\.(js|jsx|ts|tsx)$/), DEBUG)
+    );
+  } catch (e) {
+    if (DEBUG) {
+      return event.respondWith(
+        new Response(e.message || e.toString(), {
+          status: 500,
+        })
+      );
+    }
+    event.respondWith(new Response("Internal Error", { status: 500 }));
+  }
+});

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "flareact-template",
+  "version": "1.0.0",
+  "author": "Josh Larson <jplhomer@gmail.com>",
+  "license": "MIT",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "flareact dev",
+    "build": "flareact build",
+    "deploy": "flareact publish"
+  },
+  "dependencies": {
+    "flareact": "^0.8.0-alpha.2",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  },
+  "devDependencies": {
+    "@types/react": "^16.9.56"
+  }
+}

--- a/examples/with-typescript/pages/index.tsx
+++ b/examples/with-typescript/pages/index.tsx
@@ -1,0 +1,19 @@
+type IndexProps = {
+  message: string;
+};
+
+export async function getEdgeProps() {
+  return {
+    props: {
+      message: "Hello",
+    } as IndexProps,
+  };
+}
+
+export default function Index({ message }: IndexProps) {
+  return (
+    <div>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/examples/with-typescript/wrangler.toml
+++ b/examples/with-typescript/wrangler.toml
@@ -1,0 +1,11 @@
+name = "flareact-ts"
+type = "webpack"
+account_id = ""
+workers_dev = true
+route = ""
+zone_id = ""
+webpack_config = "node_modules/flareact/webpack"
+
+[site]
+bucket = "out"
+entry-point = "./"


### PR DESCRIPTION
This adds docs for using TypeScript with Flareact.

It also uses a very, very simple TypeScript example.

cc #20 