### PR TITLE
Improve dev server

### DIFF
--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -210,6 +210,7 @@ module.exports = (env, argv) => {
     },
     plugins: [new MiniCssExtractPlugin(), new BuildManifestPlugin()],
     devServer: {
+      index: "",
       contentBase: path.resolve(projectDir, "out"),
       hot: true,
       hotOnly: true,
@@ -217,6 +218,10 @@ module.exports = (env, argv) => {
       noInfo: true,
       headers: {
         "access-control-allow-origin": "*",
+      },
+      proxy: {
+        "/": "http://localhost:8787",
+        "/_flareact": "http://localhost:8787",
       },
     },
     devtool: dev ? "source-map" : false,

--- a/src/bin/flareact.js
+++ b/src/bin/flareact.js
@@ -35,7 +35,7 @@ const argv = yargs
   .alias("help", "h").argv;
 
 if (argv._.includes("dev")) {
-  console.log("Starting Flareact dev server...");
+  console.log("🚀 Starting Flareact dev server on http://localhost:8080 ...\n");
 
   concurrently(
     [


### PR DESCRIPTION
- Proxy wrangler requests through single dev server
- This allows React Fast Refresh + error catching to actually work 😍 
- Biggest change: **Dev server is at localhost:8080 now instead of 127.0.0.1:8787**. The old endpoint continues to work, however.

Future improvements:

- Unfortunately, you still see the wrangler `Listening on...` message. Hopefully the first Flareact logger will be enough to convince people to click on it
- Would be nice to be able to customize the port the dev server listens on.