### PR TITLE
feat: add script tag support to flareactHead

### DIFF
--- a/src/components/_document.js
+++ b/src/components/_document.js
@@ -61,6 +61,7 @@ export function FlareactHead({ helmet, page, buildManifest }) {
       {helmet.title.toComponent()}
       {helmet.meta.toComponent()}
       {helmet.link.toComponent()}
+      {helmet.script.toComponent()}
 
       {[...links].map((link) => (
         <link href={`/_flareact/static/${link}`} rel="stylesheet" />


### PR DESCRIPTION
We would like to add some script to the Head element, as we would love to execute theme change before anything starts to render. The change will allow the following script to be included in ssr response
```javascript
<Head>
  <title>Hellow World</title>
  <script>{`
    // ...
  `}
  </script>
</Head>
```
https://github.com/nfl/react-helmet#server-usage