### PR TITLE
fix: add watchOptions.ignored for "Error: ENOSPC"

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = function ({ dev, isServer }) {
     plugins: [new MiniCssExtractPlugin()],
     stats: "errors-warnings",
     watchOptions: {
-      ignored: /node_modules/
+      ignored: ['**/.git/**', '**/node_modules/**', '**/out/**']
     },
     module: {
       rules: [

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -25,6 +25,9 @@ module.exports = function ({ dev, isServer }) {
     context: process.cwd(),
     plugins: [new MiniCssExtractPlugin()],
     stats: "errors-warnings",
+    watchOptions: {
+      ignored: 'node_modules/**'
+    },
     module: {
       rules: [
         {

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = function ({ dev, isServer }) {
     plugins: [new MiniCssExtractPlugin()],
     stats: "errors-warnings",
     watchOptions: {
-      ignored: 'node_modules/**'
+      ignored: /node_modules/
     },
     module: {
       rules: [


### PR DESCRIPTION
First of all, I'm so excited about this framework, it's so brilliant.
When I use the template project, I meet this warning:
```
[client] Error from chokidar (/my-project-path/node_modules/webpack/hot): Error: ENOSPC: System limit for number of file watchers reached, watch '/my-project-path/node_modules/webpack/hot/only-dev-server.js'
```
I realized maybe the webpack config miss watchOptions so all files in `node_modules` were watched.
My environment is a remote VSCode Server, so I found [this solution](https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc), but this solution needs modification about `/proc/sys/` files, it's seems not good.
Then I found [this](https://webpack.js.org/configuration/watch/#watchoptionsignored) in official document, about ignore watching `node_modules`, this may be the best way.
Next.js use [this config](https://github.com/vercel/next.js/blob/30c2dfdc47603ba68bc54ba5f716435385907361/packages/next/build/webpack-config.ts#L785) to ignore large workspace, I think we should have the same config about watchOptions.ignored.