### PR TITLE
draft feat: add custom response support in pages.

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -144,6 +144,11 @@ async function handleCachedPageRequest(
   const page = getPage(normalizedPathname, context);
   const props = await getPageProps(page, query);
 
+  // If custom response detected, direct return
+  if(props && props.response && props.response instanceof Response) {
+    return props.response
+  }
+
   let response = generateResponse(page, props);
 
   // Cache by default

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -92,10 +92,11 @@ export async function getPageProps(page, query) {
   };
 
   if (fetcher) {
-    const { props, revalidate } = await fetcher({ params, query: queryObject });
+    const { props, revalidate, response } = await fetcher({ params, query: queryObject });
 
     pageProps = {
       ...props,
+      response,
       revalidate,
     };
   }


### PR DESCRIPTION
Hello, I have some new ideas to share.
I have a very simple Worker to generate my own "short url service", which actually uses HTTP Code 302 & Worker KV. I really want to migrate in flareact, but `/api/*` path cannot fix my current path (e.g. `/s/abced` will return a 302).
I thought about another case, that Worker return different response in same path, but different condition. For example, the refer, or some exact url params.
In Next.js, there are two ways to have a redirect path, in `next.config.js` ([refer](https://nextjs.org/docs/api-reference/next.config.js/redirects)) or in the `getStaticProps` ([refer](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)).
Although Next.js has a notice, 

> Note: Redirecting at build-time is currently not allowed.

I think flexibility and light-weight is Worker's advantage, so giving the ability of customing response to our users may be a good feature.
Waiting for your ideas and considerations!