### PR TITLE
fix: Include a build ID within _buildManifest path

### DIFF
--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -11,11 +11,17 @@ const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const glob = require("glob");
 const BuildManifestPlugin = require("./webpack/plugins/build-manifest-plugin");
 const crypto = require("crypto");
+const { nanoid } = require("nanoid");
 
 const projectDir = process.cwd();
 const flareact = flareactConfig(projectDir);
 const dev = process.env.NODE_ENV === "development";
 const isServer = false;
+
+// Note: This buildId does NOT match that which is running in webpack.worker.config.js.
+// This is merely used as a client cache-busting mechanism for items that absolutely change
+// between deploys, e.g. build manifests.
+const buildId = dev ? "dev" : nanoid();
 
 const pageManifest = glob.sync("./pages/**/*.js");
 
@@ -208,7 +214,7 @@ module.exports = (env, argv) => {
       path: path.resolve(projectDir, "out/_flareact/static"),
       chunkFilename: `${dev ? "[name]" : "[name].[contenthash]"}.js`,
     },
-    plugins: [new MiniCssExtractPlugin(), new BuildManifestPlugin()],
+    plugins: [new MiniCssExtractPlugin(), new BuildManifestPlugin({ buildId })],
     devServer: {
       index: "",
       contentBase: path.resolve(projectDir, "out"),

--- a/configs/webpack/plugins/build-manifest-plugin.js
+++ b/configs/webpack/plugins/build-manifest-plugin.js
@@ -1,11 +1,15 @@
 const { RawSource } = require("webpack-sources");
 
 module.exports = class BuildManifestPlugin {
+  constructor({ buildId }) {
+    this.buildId = buildId;
+  }
+
   createAssets(compilation, assets) {
     const namedChunks = compilation.namedChunks;
 
     const assetMap = {
-      helpers: ["_buildManifest.js"],
+      helpers: [`${this.buildId}/_buildManifest.js`],
       pages: {},
     };
 
@@ -35,7 +39,7 @@ module.exports = class BuildManifestPlugin {
       JSON.stringify(assetMap, null, 2)
     );
 
-    assets["_buildManifest.js"] = new RawSource(
+    assets[`${this.buildId}/_buildManifest.js`] = new RawSource(
       `self.__BUILD_MANIFEST = ${generateClientManifest(
         assetMap
       )};self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB();`


### PR DESCRIPTION
Otherwise, this file is cached in browser for one year.