### PR TITLE
feat: add redirect prop in getEdgeProps.

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -144,6 +144,22 @@ async function handleCachedPageRequest(
   const page = getPage(normalizedPathname, context);
   const props = await getPageProps(page, query);
 
+  // If custom response detected, direct return
+  if(props && props.redirect) {
+    // redirect should be used in condition when necessary, if so, warn with path.
+    if(Object.keys(props).length !== 1 && dev) {
+      console.log("[Error] in \"" + page.pagePath + "\", \"redirect\" without condition is strongly not recommended!")
+    }
+    // catch wrong config and make a waring.
+    if(props.redirect && !props.redirect.destination && dev) {
+      console.log("[Error] in \"" + page.pagePath + "\", \"redirect\" has no destination!")
+    }
+    // redirect in getEdgeProps has only 2 property, destination & permanent
+    if(props.redirect.destination) {
+      return Response.redirect(props.redirect.destination, props.redirect.permanent ? 308 : 307)
+    }
+  }
+
   let response = generateResponse(page, props);
 
   // Cache by default

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -92,11 +92,12 @@ export async function getPageProps(page, query) {
   };
 
   if (fetcher) {
-    const { props, revalidate } = await fetcher({ params, query: queryObject });
+    const { props, revalidate, redirect } = await fetcher({ params, query: queryObject });
 
     pageProps = {
       ...props,
       revalidate,
+      redirect
     };
   }
 


### PR DESCRIPTION
Hello Josh, here is my new PR.

Recently I've learned how Next.js "rewrites & redirects" works. I found that it contains two parts, static map and dynamic redirect, based on it's `next-server`.

So this PR is the dynamic part, which gives developer a way to make a redirect in some condition. If not, there will be a warning when `DEBUG=true` 😆 !

I think the static part may be not the best way for Workers, so I create a [package](https://www.npmjs.com/package/cf-worker-gateway) as "gateway", I'd like to give an example if you need.

Any suggestions please reply, and I'll catch later.