### PR TITLE
fix: fix `resolvePagePath` regexp

### DIFF
--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -14,10 +14,10 @@ export function resolvePagePath(pagePath, keys) {
         parts.push(match[1]);
       }
 
-      test = test.replace(DYNAMIC_PAGE, () => "([\\w_-]+)");
+      test = test.replace(DYNAMIC_PAGE, () => "(\\[(\\w+)\\])");
     }
 
-    test = test.replace("/", "\\/").replace(/^\./, "").replace(/\.js$/, "");
+    test = test.replace(/\//g, "\\/").replace(/^\./, "").replace(/\.js$/, "");
 
     return {
       page,


### PR DESCRIPTION
Maybe I found a bug in `resolvePagePath` function.

version: 0.10.0
example: A request to such path `/api/v1/shorten/[slug]`

During my debug, resolvePagePath cannot recognize that this is an api path, instead, it tried to find `index.html`.

I've made a fix that works with my example, you can make a further test.