### PR TITLE
bug: Dynamic Page Matches Custom App Page (_app.js) Causing Rendering Failure

### DIFF
--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -7,8 +7,10 @@ export function resolvePagePath(pagePath, keys) {
     let test = page;
     let parts = [];
 
-    const isDynamic = DYNAMIC_PAGE.test(page);
-
+    
+    // treat /_app as a special case; as the "layout" it should never match a dynamic page
+    const isDynamic = pagePath != "/_app" && DYNAMIC_PAGE.test(page);
+    
     if (isDynamic) {
       for (const match of page.matchAll(/\[(\w+)\]/g)) {
         parts.push(match[1]);

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -73,3 +73,16 @@ it("matches multiple dynamic pages", () => {
     slug: "hello-world-it-me",
   });
 });
+
+it("does not mistake _app for a dynamic page", () => {
+  const path = resolvePagePath("/_app", ["./[slug].js", "./_app.js"]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./_app.js");
+});
+
+it("returns when _app is missing", () => {
+  const path = resolvePagePath("/_app", ["./[slug].js"]);
+
+  expect(path).toBe(null);
+});


### PR DESCRIPTION
This PR is intended to address https://github.com/flareact/flareact/issues/70

The following Dynamic Page configuration will cause rendering errors because the "App" component/page will resolve to [group].js rather than _app.js

```
pages/[group].js
pages/_app.js
pages/posts/[slug].js
```

This occurs because the test for isDynamic in the resolvePagePath function will match the page path "_app.js" to the dynamic page "[group].js"

Thus the App Provider will render the component defined in [group].js as the "App" component rather than the component defined in _app.js (see https://github.com/flareact/flareact/blob/0e03f783b0fe38e827b2abc76008a42485002ebf/src/worker/render.js#L10]

To address this treat [fetching the /_app.js page](https://github.com/flareact/flareact/blob/0e03f783b0fe38e827b2abc76008a42485002ebf/src/worker/render.js#L10) as a special case and ignore any dynamic pages when resolving the pagePath