### PR TITLE
Fix hash routing weirdness

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -111,9 +111,11 @@ export function RouterProvider({
           asPath: state.asPath,
         };
       } else {
+        const { pathname, search, hash } = window.location;
+
         newRoute = {
-          href: window.location.pathname || "/",
-          asPath: window.location.pathname || "/",
+          href: pathname || "/",
+          asPath: pathname + search + hash || "/",
         };
       }
 


### PR DESCRIPTION
fix: Ensure hash is included in new asPath during popstate

Seeing a bunch of `window.scrollTo(0, 0)` even when I'm clicking on plain hash anchors on the docs site. This is obviously a bug, and I think it has to do with `popstate` handling of new routes. 

Ugh - hope this is a good solution. There are probably a lot of leaks in the router.