### PR TITLE
feat: add event argument to getPageProps

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -106,7 +106,7 @@ async function handleCachedPageRequest(
   if (!dev && cachedResponse) return cachedResponse;
 
   const page = getPage(normalizedPathname, context);
-  const props = await getPageProps(page, query);
+  const props = await getPageProps(page, query, event);
 
   let response = await generateResponse(page, props);
 

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -103,7 +103,7 @@ export function getPage(pagePath, context) {
   }
 }
 
-export async function getPageProps(page, query) {
+export async function getPageProps(page, query, event) {
   let pageProps = {};
 
   const params = page.params || {};
@@ -116,7 +116,7 @@ export async function getPageProps(page, query) {
   };
 
   if (fetcher) {
-    const { props, revalidate } = await fetcher({ params, query: queryObject });
+    const { props, revalidate } = await fetcher({ params, query: queryObject, event });
 
     pageProps = {
       ...props,


### PR DESCRIPTION
**What does this PR do?**
It passes the `event` supplied to `handleCachedPageRequest` to the `getPageProps` method, allowing us to access `event` in the `getEdgeProps` method.

The example use case is described in #82. I also realised that the implementation itself is not new as this has been implemented in @cj's PR in #61 so this just pulls this feature out into its own smaller PR.