### PR TITLE
enhancement(cli): Improve console message when starting dev server.

### DIFF
--- a/src/bin/flareact.js
+++ b/src/bin/flareact.js
@@ -35,7 +35,10 @@ const argv = yargs
   .alias("help", "h").argv;
 
 if (argv._.includes("dev")) {
-  console.log("🚀 Starting Flareact dev server on http://localhost:8080 ...\n");
+  console.log("⏰ Wait for Wrangler dev server to start on port 8787 first.");
+  console.log(
+    "🚀 Then, Flareact dev server will be on http://localhost:8080 ...\n"
+  );
 
   concurrently(
     [


### PR DESCRIPTION
Old message:
	🚀 Starting Flareact dev server on http://localhost:8080 ...

New message:
	⏰ Wait for Wrangler dev server to start on port 8787 first.
	🚀 Then, Flareact dev server will be on http://localhost:8080 ...

The old message seems to tell that the server is already started, and user will be able to access it in the browser even before the Wrangler dev server is started. But, if they do that ECONNREFUSED error will be printed on the console.

We need to tell users explicitly that Wrangler dev server needs to start first for the proxy to work.