### PR TITLE
Fix css modules example to have correct class name

### DIFF
--- a/docs/built-in-css-support.md
+++ b/docs/built-in-css-support.md
@@ -52,7 +52,7 @@ Next, create your component and import the CSS module as you would any other dep
 import styles from "./Alert.module.css";
 
 export default function Alert() {
-  return <p className={styles.paragraph}>Alert!</p>;
+  return <p className={styles.text}>Alert!</p>;
 }
 ```
 


### PR DESCRIPTION
I'm loving this project, thanks for the hardwork bootstrapping this! I have a Nextjs application that I'm looking to port over to flareact to take advantage of some cloudflare worker features.

Looking through the docs, I noticed that the css module example had a class name mismatch between the css file and the react component. This is not a big fix, but hopefully this can help avoid some confusion if someone is trying to follow the docs to get started with css modules.