### PR TITLE
fix: unicode in dynamic pages

### DIFF
--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -19,7 +19,7 @@ export function resolvePagePath(pagePath, keys) {
         parts.push(match[1]);
       }
 
-      test = test.replace(DYNAMIC_PAGE, () => "([\\w_-]+)");
+      test = test.replace(DYNAMIC_PAGE, () => "([^\/]+)");
     }
 
     test = test.replace("/", "\\/").replace(/^\./, "").replace(/\.(js|jsx|ts|tsx)$/, "");

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -23,6 +23,18 @@ it("matches dynamic pages", () => {
   expect(path.params).toEqual({ slug: "hello" });
 });
 
+it("matches dynamic pages with unicode", () => {
+  const path = resolvePagePath("/posts/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9", [
+    "./index.js",
+    "./apples.js",
+    "./posts/[slug].js",
+  ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/[slug].js");
+  expect(path.params).toEqual({ slug: "%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9" });
+});
+
 it("matches dynamic page indexes", () => {
   const path = resolvePagePath("/posts", [
     "./index.js",
@@ -71,6 +83,21 @@ it("matches multiple dynamic pages", () => {
   expect(path.params).toEqual({
     category: "travel",
     slug: "hello-world-it-me",
+  });
+});
+
+it("matches multiple dynamic pages with unicode", () => {
+  const path = resolvePagePath("/posts/%D7%A2%D7%91%D7%A8%D7%99%D7%AA/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9", [
+    "./index.js",
+    "./apples.js",
+    "./posts/[category]/[slug].js",
+  ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/[category]/[slug].js");
+  expect(path.params).toEqual({
+    category: "%D7%A2%D7%91%D7%A8%D7%99%D7%AA",
+    slug: "%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9",
   });
 });
 


### PR DESCRIPTION
Allows any characters other than `/` in dynamic pages. Any other potentially "breaking" characters should be url encoded by the user and not part of flareact.