### PR TITLE
fix: wrong path in webpack chunks

### DIFF
--- a/configs/webpack.client.config.js
+++ b/configs/webpack.client.config.js
@@ -212,6 +212,7 @@ module.exports = (env, argv) => {
     },
     output: {
       path: path.resolve(projectDir, "out/_flareact/static"),
+      publicPath: "/_flareact/static/",
       chunkFilename: `${dev ? "[name]" : "[name].[contenthash]"}.js`,
     },
     plugins: [


### PR DESCRIPTION
Imports spllited to chunks by webpack loading from relative path and not from  `/_flareact/static/`.