### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Right — *another* React framework. Here's why Flareact might be useful to you
 ## Examples
 
 - [Flareact Docs (this site)](https://github.com/flareact/flareact-site/)
-- [Headless CMS: WordPress](https://github.com/flareact/flareact/tree/master/examples/with-cms-wordpress)
+- [Headless CMS: WordPress](https://github.com/flareact/flareact/tree/main/examples/with-cms-wordpress)
 
 ## About
 


### PR DESCRIPTION
`master` branch has been renamed to `main` 

![image](https://user-images.githubusercontent.com/10026538/107127449-13c1d380-68ae-11eb-8857-e9f67896400b.png)
