### PR TITLE
Document custom 404 Not Found page

### DIFF
--- a/docs/custom-404-error-page.md
+++ b/docs/custom-404-error-page.md
@@ -1,0 +1,27 @@
+# Custom 404 Not Found Error Page
+
+Accessing a path that has no corresponding [page](/docs/pages) will give the following, unstyled, 404 Not Found error message:
+
+```
+could not find some-path/index.html in your content namespace
+```
+
+If you want to customize the 404 Not Found page for your application, you can add a static `404.html` HTML document in `/public`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>404 Not Found</title>
+  </head>
+  <body>
+    <h1>404 Not Found</h1>
+    <p>The page cannot be found.</p>
+  </body>
+</html>
+```
+
+You can reference other assets, such as stylesheets and images, stored as [static files](/docs/static-file-serving) from within the HTML document.
+
+Note that it is currently **not possible to use a React page component** from `/pages` to generate the 404 Not Found page.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -52,6 +52,10 @@
     "title": "Custom PostCSS Config"
   },
   {
+    "url": "/docs/custom-404-error-page",
+    "title": "Custom 404 Not Found Error Page"
+  },
+  {
     "url": "/docs/custom-webpack-config",
     "title": "Custom Webpack Config"
   },

--- a/docs/static-file-serving.md
+++ b/docs/static-file-serving.md
@@ -5,3 +5,7 @@ When you add files to a `/public` folder in your project, Flareact will serve th
 For example, if you add `public/favicon.ico` locally, it will be served at `site.com/favicon.ico`.
 
 Behind the scenes, Cloudflare stores these assets in the [Workers KV](https://www.cloudflare.com/products/workers-kv/) and serves them directly on the edge.
+
+## Adding a custom 404 Not Found error page
+
+By adding a `/public/404.html` HTML document, you can customize the 404 Not Found error page. See [Custom 404 Not Found Error Page](/docs/custom-404-error-page).


### PR DESCRIPTION
As discussed in https://github.com/flareact/flareact/discussions/130 it is currently not possible to add a custom 404 Not Found page in `/pages/404.js`, [like with Next.js](https://nextjs.org/docs/advanced-features/custom-error-page#404-page).

It _is_ however, possible to add a static `/public/404.html` that is rendered as the 404 Not Found error document. This follows the convention from many static hosting platforms, e.g. [GitHub pages](https://docs.github.com/en/github/working-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site), and is documented in the [Cloudflare worker sites template](https://github.com/cloudflare/worker-sites-template/blob/master/public/404.html).

This behavior is implemented in `worker.js`:

https://github.com/flareact/flareact/blob/0e1726fe61f7e684d2e3be619fc2ce03a178cb05/src/worker/worker.js#L30-L36

This PR simply documents the existing behavior in a new _Custom 404 Not Found Error Page_ entry. It is also mentioned in the existing _Static File Serving_ entry, since this is a static file with a somewhat magic behavior.