### PR TITLE
Feature/404 response

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -77,8 +77,14 @@ export async function handleRequest(event, context, fallback) {
           buildManifest,
         });
 
+        let statusCode = 200;
+
+        if (typeof props.notFound !== "undefined" && props.notFound === true) {
+            statusCode = 404;
+        }
+
         return new Response(html, {
-          status: 200,
+          status: statusCode,
           headers: { "content-type": "text/html" },
         });
       }

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -116,10 +116,11 @@ export async function getPageProps(page, query, event) {
   };
 
   if (fetcher) {
-    const { props, revalidate } = await fetcher({ params, query: queryObject, event });
+    const { props, notFound, revalidate } = await fetcher({ params, query: queryObject, event });
 
     pageProps = {
       ...props,
+      notFound,
       revalidate,
     };
   }


### PR DESCRIPTION
### Problem
Need to be able to return a 404 programmatically on hard navigation for SEO optimization.

### Current Behaviour
Currently there is no way to return a 404 response if conditions are not met during getEdgeProps. For example attempting to get some data from KV store which could not be found.

### Solution
Next.js provides a "notFound" parameter which can be added to the return props. Setting this to true will result in a 404 response being returned ([Docs link here](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)).

Current implementation only returns a 404 on hard navigation. Soft navigation will still return a 200. However the "notFound" prop will still be present to be able to control the content displayed as normal.

Example props object:
```
return {
    props: {
        someParam: "someData"
    },
    notFound: true,
    revalidate: 0
}
```

Example returned props JSON:
```json
    "pageProps": {
        "someParam": "someData",
        "notFound": true,
        "revalidate": 0
    }
````



Originally discussed in #158 