### PR TITLE
Add cargo-generate.toml to Manual Installation steps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,6 +53,7 @@ Next, make sure you have the following files (check out the [template repo](http
 
 - `index.js`
 - `wrangler.toml`
+- `cargo-generate.toml`
 
 Open `package.json` file and add the following `scripts`:
 


### PR DESCRIPTION
I'm a wrangler noob and kept receiving this error when trying to run `npm run dev` in a new Flareact project:

```
[HPM] Error occurred while trying to proxy request / from localhost:8080 to http://localhost:8787 (ECONNREFUSED)
```

I couldn't figure out why port 8787 wasn't connecting.  Turns out I was missing the cargo-generate.toml file + contents.  Added this and Flareact started working straight away.

Hopefully this will help somebody in the future with the same issue as me.