### PR TITLE
fixed hydration of path/index files

### DIFF
--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -64,6 +64,13 @@ export function resolvePagePath(pagePath, keys) {
   }
 
   if (!page) return null;
+
+  /**
+   * If pagePath ends in /index trim it off (unless page is /index) to match router
+   * returned pagePath for the same page
+   */
+  page.pagePath = page.pagePath.replace(/(?=.)\/index$/, "");
+
   if (!page.parts.length) return page;
 
   let params = {};


### PR DESCRIPTION
When a page like /path/index.js is hard loaded the returned page path is /path/index. When attempting to load /path/index on the client side, the promise is never resolved and so the page is never hydrated. Have trimmed the /index from the end of the page path to match the router returned page path which does allow hydration to happen.