### PR TITLE
catch all routes

### DIFF
--- a/docs/dynamic-routes.md
+++ b/docs/dynamic-routes.md
@@ -48,6 +48,23 @@ The params passed to your `getEdgeProps` function will contain each dynamic path
 }
 ```
 
+## Catch all routes
+
+Dynamic routes can be extended to catch all paths by adding three dots `(...)` inside the brackets. For example:
+
+```
+/pages/posts/[..slug].js
+```
+
+`/pages/post/[...slug].js` matches `/pages/post/a`, but also `/pages/post/a/b`, `/pages/post/a/b/c` and so on.
+
+
+The params passed to your `getEdgeProps` function will contain a dynamic path property with an array of the passed parameters:
+
+```
+{ "slug": ["a", "b"] }
+```
+
 You can also reference the query params with the `useRouter` hook in your component:
 
 ```js

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -71,6 +71,32 @@ it("matches longer dynamic pages", () => {
   expect(path.params).toEqual({ slug: "hello-world-it-me" });
 });
 
+it("matches catch-all dynamic page", () => {
+  const path = resolvePagePath("/posts/hello-world/it/me", [
+    "./index.js",
+    "./apples.js",
+    "./posts/[...category].js",
+  ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/[...category].js");
+  expect(path.params).toEqual({
+    category: ["hello-world","it","me"],
+  });
+});
+
+it("matches catch-all dynamic page indexes", () => {
+  const path = resolvePagePath("/posts", [
+    "./index.js",
+    "./apples.js",
+    "./posts/[...category].js",
+    "./posts/index.js",
+  ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/index.js");
+});
+
 it("matches multiple dynamic pages", () => {
   const path = resolvePagePath("/posts/travel/hello-world-it-me", [
     "./index.js",


### PR DESCRIPTION
Added support for cache all routes. Modeled after [NextJS Dynamic Routes](https://nextjs.org/docs/routing/dynamic-routes)

Dynamic routes can be extended to catch all paths by adding three dots `(...)` inside the brackets. For example:

```
/pages/posts/[..slug].js
```

`/pages/post/[...slug].js` matches `/pages/post/a`, but also `/pages/post/a/b`, `/pages/post/a/b/c` and so on.


The params passed to your `getEdgeProps` function will contain a dynamic path property with an array of the passed parameters:

```
{ "slug": ["a", "b"] }
```

#86 

