### PR TITLE
Custom headers

### DIFF
--- a/docs/custom-headers.md
+++ b/docs/custom-headers.md
@@ -1,0 +1,18 @@
+# Custom Headers
+
+Often times, you want to set custom response headers(eg 'set-cookie').
+
+Pass a header object to `customHeaders` to tell Flareact to add those headers:
+
+```js
+export async function getEdgeProps() {
+  const data = await someExpensiveDataRequest();
+
+  return {
+    props: {
+      data,
+    },
+    customHeaders: {'set-cookie': 'cookie=monster; Expires=Wed, 21 Oct 2025 07:28:00 GMT'},
+  };
+}
+```

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -83,9 +83,15 @@ export async function handleRequest(event, context, fallback) {
             statusCode = 404;
         }
 
+        let headers = { "content-type": "text/html" }
+
+        if (typeof props.customHeaders !== "undefined") {
+          headers = {...headers, ...props.customHeaders};
+        }
+
         return new Response(html, {
           status: statusCode,
-          headers: { "content-type": "text/html" },
+          headers: headers,
         });
       }
     );

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -135,11 +135,12 @@ export async function getPageProps(page, query, event) {
   };
 
   if (fetcher) {
-    const { props, notFound, revalidate } = await fetcher({ params, query: queryObject, event });
+    const { props, notFound, customHeaders, revalidate } = await fetcher({ params, query: queryObject, event });
 
     pageProps = {
       ...props,
       notFound,
+      customHeaders,
       revalidate,
     };
   }


### PR DESCRIPTION
Often times, you want to set custom response headers(eg 'set-cookie').

Pass a header object to `customHeaders` to tell Flareact to add those headers:

```js
export async function getEdgeProps() {
  const data = await someExpensiveDataRequest();
  return {
    props: {
      data,
    },
    customHeaders: {'set-cookie': 'cookie=monster; Expires=Wed, 21 Oct 2025 07:28:00 GMT'},
  };
}
```

#199 