### PR TITLE
fix: disabled fibers for node 16

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = function ({ dev, isServer }) {
     loader: MiniCssExtractPlugin.loader,
   };
 
-  const sassOptionFiber = false;
+  let sassOptionFiber = false;
 
   // Check if we can enable fibers or not. Its not supported in node versions 16 and up.
   if (parseInt(process.versions.node.split('.')[0]) < 16) {

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -21,12 +21,19 @@ module.exports = function ({ dev, isServer }) {
     loader: MiniCssExtractPlugin.loader,
   };
 
+  const sassOptionFiber = false;
+
+  // Check if we can enable fibers or not. Its not supported in node versions 16 and up.
+  if (parseInt(process.versions.node.split('.')[0]) < 16) {
+    sassOptionFiber = require("fibers");
+  }
+
   const sassLoader = {
     loader: "sass-loader",
     options: {
       implementation: require("sass"),
       sassOptions: {
-        fiber: require("fibers"),
+        fiber: sassOptionFiber
       },
     },
   };


### PR DESCRIPTION
Disabled Fibers requirement if on Node 16 or greater. Not supported anymore with no plans to support in the future. See package [readme](https://github.com/laverdet/node-fibers).

Still works if using node versions less than 16. Update adds a check to the build for node runtime version.

Resolves #153 