### PR TITLE
feat: disable scrolling to the top of the page

### DIFF
--- a/docs/flareact-link.md
+++ b/docs/flareact-link.md
@@ -58,3 +58,27 @@ export default function Index() {
   );
 }
 ```
+
+## Scroll
+
+The default behaviour of the Link component is to scroll to the top of the page.
+When there's a hash defined, it will scroll to the specific ID.
+
+This feature is useful for a layered component where each tab needs to update the route.
+By default, the scroll would go to the top of the page, but the correct behaviour is to update the route and change the tab's content.
+
+You can disable this behaviour by passing a `false` value to `scroll`:
+
+```js
+import Link from "flareact/link";
+
+export default function Index() {
+  return (
+    <div>
+      <Link href="/about" scroll={false}>
+        <a>Change route without scrolling top</a>
+      </Link>
+    </div>
+  );
+}
+```

--- a/src/link.js
+++ b/src/link.js
@@ -1,4 +1,5 @@
 import React, { Children, useEffect, useState } from "react";
+
 import { useRouter } from "./router";
 
 let prefetched = {};
@@ -15,7 +16,7 @@ export default function Link(props) {
   const [childElm, setChildElm] = useState();
   const child = Children.only(props.children);
 
-  const { href, as } = props;
+  const { href, as, scroll = true } = props;
 
   const shouldPrefetch = props.prefetch !== false;
 
@@ -54,7 +55,7 @@ export default function Link(props) {
 
     e.preventDefault();
 
-    router.push(href, as);
+    router.push(href, as, scroll);
   }
 
   const childProps = {

--- a/src/link.js
+++ b/src/link.js
@@ -1,5 +1,4 @@
 import React, { Children, useEffect, useState } from "react";
-
 import { useRouter } from "./router";
 
 let prefetched = {};

--- a/src/router.js
+++ b/src/router.js
@@ -110,12 +110,13 @@ export function RouterProvider({
     return pageProps.revalidate;
   }
 
-  function push(href, as) {
+  function push(href, as, scroll) {
     const asPath = as || href;
 
     setRoute({
       href,
       asPath,
+      scroll
     });
 
     // Blank this out so any return trips to the original component re-fetches props.

--- a/src/router.js
+++ b/src/router.js
@@ -14,12 +14,9 @@ export function RouterProvider({
   initialComponent,
   pageLoader,
 }) {
-  const {
-    protocol,
-    host,
-    pathname: initialPathname,
-    search,
-  } = new URL(initialUrl);
+  const { protocol, host, pathname: initialPathname, search } = new URL(
+    initialUrl
+  );
   const [route, setRoute] = useState({
     href: initialPagePath,
     asPath: initialPathname + search,
@@ -51,7 +48,7 @@ export function RouterProvider({
   useEffect(() => {
     // On initial page load, replace history state with format expected by router
     window.history.replaceState(route, null, route.asPath);
-  }, []);
+  }, [])
 
   useEffect(() => {
     async function loadNewPage() {
@@ -59,10 +56,7 @@ export function RouterProvider({
       const pagePath = normalizePathname(href);
       const normalizedAsPath = normalizePathname(asPath);
 
-      if (
-        !pageCache[normalizedAsPath] ||
-        hasPagePropsExpired(pageCache[normalizedAsPath].expiry)
-      ) {
+      if ( !pageCache[normalizedAsPath] || hasPagePropsExpired(pageCache[normalizedAsPath].expiry)) {
         const page = await pageLoader.loadPage(pagePath);
         const { pageProps } = await pageLoader.loadPageProps(normalizedAsPath);
         const revalidateSeconds = getRevalidateValue(pageProps);
@@ -93,7 +87,7 @@ export function RouterProvider({
       return null;
     }
 
-    return Date.now() + seconds * 1000;
+    return Date.now() + (seconds * 1000);
   }
 
   function hasPagePropsExpired(expiry) {


### PR DESCRIPTION
Hello there, 

I'm developing a project using Flareact at my company. We miss having the option to disable the scroll from going to the top of the page when the Link component gets clicked. Ref: `https://nextjs.org/docs/api-reference/next/link#disable-scrolling-to-the-top-of-the-page`.

With this PR, I'm proposing this feature to Flareact.

## Problem
The default behaviour of the Link component is to scroll to the top of the page.
When there's a hash defined, it will scroll to the specific ID.

## Why is useful

This feature is useful for a layered component where each tab needs to update the route.
By default, the scroll would go to the top of the page, but the correct behaviour is to update the route and change the tab's content.

## How to use it

You can disable this behaviour by passing a `false` value to `scroll`:

```js
import Link from "flareact/link";
export default function Index() {
  return (
    <div>
      <Link href="/about" scroll={false}>
        <a>Change route without scrolling top</a>
      </Link>
    </div>
  );
}
```