### PR TITLE
Flareact powered 404 page

### DIFF
--- a/docs/custom-404-error-page.md
+++ b/docs/custom-404-error-page.md
@@ -6,6 +6,8 @@ Accessing a path that has no corresponding [page](/docs/pages) will give the fol
 could not find some-path/index.html in your content namespace
 ```
 
+## Static html page
+
 If you want to customize the 404 Not Found page for your application, you can add a static `404.html` HTML document in `/public`:
 
 ```html
@@ -24,4 +26,38 @@ If you want to customize the 404 Not Found page for your application, you can ad
 
 You can reference other assets, such as stylesheets and images, stored as [static files](/docs/static-file-serving) from within the HTML document.
 
-Note that it is currently **not possible to use a React page component** from `/pages` to generate the 404 Not Found page.
+## React powered 404 page
+
+To create a custom React powered 404 page you can create a `pages/404.js` file.
+
+```
+// pages/404.js
+export async function getEdgeProps({ params }) {
+    const { originalPath } = params;
+    const data = await someFallbackDataRequest();
+    
+    return {
+        props: {
+            originalPath,
+            data,
+        },
+        notFound: true, // send 404 header
+        revalidate: 60, // Revalidate your data once every 60 seconds
+    }
+}
+
+export default function Index({ originalPath, data }) {
+    return (
+        <div>
+          <h1>{originalPath} - 404 Not Found </h1>
+          <ul>
+            {data.map((item) => {
+              return <li key={item.id}>...</li>;
+            })}
+          </ul>
+        </div>
+    )
+}
+```
+
+Note: `404.js` will take precedence over `404.html`. A 404 response will be returned on hard page loads only.

--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -75,7 +75,17 @@ export function resolvePagePath(pagePath, keys) {
     page = pagesMap.find((p) => p.test.test(pagePath + "/index"));
   }
 
-  if (!page) return null;
+  /**
+   * No page found, try serving 404.js
+   */
+  if (!page) {
+    return {
+      page: './404.js',
+      params: {
+        originalPath: pagePath
+      }
+    }
+  }
 
   /**
    * If pagePath ends in /index trim it off (unless page is /index) to match router


### PR DESCRIPTION
To create a custom React powered 404 page you can create a `pages/404.js` file.

```
// pages/404.js
export async function getEdgeProps({ params }) {
    const { originalPath } = params;
    const data = await someFallbackDataRequest();
    
    return {
        props: {
            originalPath,
            data,
        },
        notFound: true, // send 404 header
        revalidate: 60, // Revalidate your data once every 60 seconds
    }
}

export default function Index({ originalPath, data }) {
    return (
        <div>
          <h1>{originalPath} - 404 Not Found </h1>
          <ul>
            {data.map((item) => {
              return <li key={item.id}>...</li>;
            })}
          </ul>
        </div>
    )
}
```