### PR TITLE
feat: navigate back in history and reload current URL

### DIFF
--- a/docs/flareact-router.md
+++ b/docs/flareact-router.md
@@ -22,5 +22,11 @@ export default function Index() {
 
   // Navigate to the dynamic route /posts/[slug] using `href`, `as`
   router.push("/posts/[slug]", "/posts/my-first-post");
+
+  // Navigate back in history
+  router.back();
+
+  // Reload the current URL
+  router.reload();
 }
 ```

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,7 @@
-import React, { useContext, useState, useEffect, useMemo } from "react";
-import { extractDynamicParams } from "./utils";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+
 import { DYNAMIC_PAGE } from "./worker/pages";
+import { extractDynamicParams } from "./utils";
 
 const RouterContext = React.createContext();
 
@@ -121,6 +122,16 @@ export function RouterProvider({
     window.history.pushState({ href, asPath }, null, asPath);
   }
 
+  // Navigate back in history
+  function back() {
+    window.history.back()
+  }
+
+  // Reload the current URL
+  function reload() {
+    window.location.reload()
+  }
+
   function prefetch(href, as, { priority } = {}) {
     if (process.env.NODE_ENV !== "production") {
       return;
@@ -191,6 +202,8 @@ export function RouterProvider({
     pathname: route.href,
     asPath: route.asPath,
     push,
+    back,
+    reload,
     prefetch,
     query,
   };


### PR DESCRIPTION
Hello there,

A small feature in flareact's router, making it easier to navigate back in history and reload the current page:

## Usage:

```
import { useRouter } from "flareact/router";

export default function Index() {
  const router = useRouter();
  
  // Navigate back in history
  router.back();

  // Reload the current URL
  router.reload();
}
```

### Back in history example:

```
import { useRouter } from 'flareact/router';

export const BackButton = () => {
    const router = useRouter();

    return <button onClick={() => router.back()}>Go back</button>;
};
```

### Reload example:
```
import { useRouter } from 'flareact/router';

export const ReloadButton = () => {
    const router = useRouter();

    return <button onClick={() => router.reload()}>Reload Page </button>;
};
```

They execute `window.history.back()` and `window.location.reload() respectively. 

Based in NextJS `back` and `reload` router functions.