### PR TITLE
fix: Adds missing feature for #230 and #229

### DIFF
--- a/src/worker/pages.js
+++ b/src/worker/pages.js
@@ -1,18 +1,23 @@
 import App from "../components/_app";
 import Document from "../components/_document";
 
+export const PAGE_EXTENSIONS = /\.(js|jsx|ts|tsx)$/;
 export const DYNAMIC_PAGE = new RegExp("\\[(\\w+)\\]", "g");
-export const CATCH_ALL = new RegExp("(.*?)\/\\[\\.\\.\\.(\\w+)\\]");
+export const CATCH_ALL = new RegExp("(.*?)/\\[\\.\\.\\.(\\w+)\\]");
 
 function isSpecialPage(pagePath) {
   return /\/_(document|app)$/.test(pagePath);
+}
+
+function isIndexPage(pageKey) {
+  return /\/[iI]ndex$/.test(pageKey);
 }
 
 export function resolvePagePath(pagePath, keys) {
   const pagesMap = keys.map((page) => {
     let test = page;
     let parts = [];
-    let params ={};
+    let params = {};
 
     const isDynamic = DYNAMIC_PAGE.test(page);
 
@@ -21,24 +26,35 @@ export function resolvePagePath(pagePath, keys) {
         parts.push(match[1]);
       }
 
-      test = test.replace(DYNAMIC_PAGE, () => "([^\/]+)");
+      test = test.replace(DYNAMIC_PAGE, () => "([^/]+)");
     }
 
-    const isCatchall = CATCH_ALL.test(page)
+    const isCatchall = CATCH_ALL.test(page);
 
     if (isCatchall) {
       const pageParts = page.match(CATCH_ALL);
-      const paths = ('.' + pagePath).replace(pageParts[1] + '/', '').split('/');
+      const paths = ("." + pagePath).replace(pageParts[1] + "/", "").split("/");
       params[pageParts[2]] = paths;
-      test = pageParts[1] + paths.map(() => '/([^/]+)').join('');
+      test = pageParts[1] + paths.map(() => "/([^/]+)").join("");
     }
 
-    test = test.replace("/", "\\/").replace(/^\./, "").replace(/\.(js|jsx|ts|tsx)$/, "");
+    test = test
+      .replace("/", "\\/")
+      .replace(/^\./, "")
+      .replace(PAGE_EXTENSIONS, "");
+
+    const pageWithoutExtension = page
+      .replace(/^\./, "")
+      .replace(PAGE_EXTENSIONS, "");
+
+    if (isDynamic && isIndexPage(pageWithoutExtension)) {
+      test = test.substr(0, test.length - "/index".length);
+    }
 
     return {
       page,
       params,
-      pagePath: page.replace(/^\./, "").replace(/\.(js|jsx|ts|tsx)$/, ""),
+      pagePath: pageWithoutExtension,
       parts,
       test: new RegExp("^" + test + "$", isDynamic ? "g" : ""),
     };
@@ -135,7 +151,11 @@ export async function getPageProps(page, query, event) {
   };
 
   if (fetcher) {
-    const { props, notFound, customHeaders, revalidate } = await fetcher({ params, query: queryObject, event });
+    const { props, notFound, customHeaders, revalidate } = await fetcher({
+      params,
+      query: queryObject,
+      event,
+    });
 
     pageProps = {
       ...props,

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -23,16 +23,29 @@ it("matches dynamic pages", () => {
   expect(path.params).toEqual({ slug: "hello" });
 });
 
-it("matches dynamic pages with unicode", () => {
-  const path = resolvePagePath("/posts/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9", [
+it("matches dynamic pages in folder with index", () => {
+  const path = resolvePagePath("/posts/hello", [
     "./index.js",
     "./apples.js",
-    "./posts/[slug].js",
+    "./posts/[slug]/index.js",
   ]);
 
   expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/[slug]/index.js");
+  expect(path.params).toEqual({ slug: "hello" });
+});
+
+it("matches dynamic pages with unicode", () => {
+  const path = resolvePagePath(
+    "/posts/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9",
+    ["./index.js", "./apples.js", "./posts/[slug].js"]
+  );
+
+  expect(path).toBeTruthy();
   expect(path.page).toBe("./posts/[slug].js");
-  expect(path.params).toEqual({ slug: "%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9" });
+  expect(path.params).toEqual({
+    slug: "%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9",
+  });
 });
 
 it("matches dynamic page indexes", () => {
@@ -81,7 +94,7 @@ it("matches catch-all dynamic page", () => {
   expect(path).toBeTruthy();
   expect(path.page).toBe("./posts/[...category].js");
   expect(path.params).toEqual({
-    category: ["hello-world","it","me"],
+    category: ["hello-world", "it", "me"],
   });
 });
 
@@ -112,12 +125,26 @@ it("matches multiple dynamic pages", () => {
   });
 });
 
-it("matches multiple dynamic pages with unicode", () => {
-  const path = resolvePagePath("/posts/%D7%A2%D7%91%D7%A8%D7%99%D7%AA/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9", [
+it("matches multiple dynamic pages with index", () => {
+  const path = resolvePagePath("/posts/travel/hello-world-it-me", [
     "./index.js",
     "./apples.js",
-    "./posts/[category]/[slug].js",
+    "./posts/[category]/[slug]/index.js",
   ]);
+
+  expect(path).toBeTruthy();
+  expect(path.page).toBe("./posts/[category]/[slug]/index.js");
+  expect(path.params).toEqual({
+    category: "travel",
+    slug: "hello-world-it-me",
+  });
+});
+
+it("matches multiple dynamic pages with unicode", () => {
+  const path = resolvePagePath(
+    "/posts/%D7%A2%D7%91%D7%A8%D7%99%D7%AA/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9",
+    ["./index.js", "./apples.js", "./posts/[category]/[slug].js"]
+  );
 
   expect(path).toBeTruthy();
   expect(path.page).toBe("./posts/[category]/[slug].js");


### PR DESCRIPTION
This adds the missing feature mentioned in #230 and #229.

The issue being that when the page file path is something like `/pages/user/[userId]/account/[accountId]/index.js` to would not recognise the path as matching to index.

This adds a check for if the file is a dynamic route and index.* file and removes that from the regex test for the page.