### PR TITLE
fix: Fix for non-get request cache error

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -2,6 +2,8 @@ import { normalizePathname } from "../router";
 import { getPage, getPageProps, PageNotFoundError } from "./pages";
 import { render } from "./render";
 
+const CACHEABLE_REQUEST_METHODS = ["GET", "HEAD"];
+
 const dev =
   (typeof DEV !== "undefined" && !!DEV) ||
   process.env.NODE_ENV !== "production";
@@ -80,13 +82,13 @@ export async function handleRequest(event, context, fallback) {
         let statusCode = 200;
 
         if (typeof props.notFound !== "undefined" && props.notFound === true) {
-            statusCode = 404;
+          statusCode = 404;
         }
 
-        let headers = { "content-type": "text/html" }
+        let headers = { "content-type": "text/html" };
 
         if (typeof props.customHeaders !== "undefined") {
-          headers = {...headers, ...props.customHeaders};
+          headers = { ...headers, ...props.customHeaders };
         }
 
         return new Response(html, {
@@ -134,7 +136,8 @@ async function handleCachedPageRequest(
     }
   }
 
-  if (shouldCache) {
+  // This API only supports caching of GET or HEAD request methods
+  if (shouldCache && CACHEABLE_REQUEST_METHODS.includes(event.request.method)) {
     await cache.put(cacheKey, response.clone());
   }
 


### PR DESCRIPTION
When doing a `POST` request to a page route e.g. a form submission the `cache.put()` errors with 
`TypeError: Cannot cache response to non-GET request.` 

It looks like upstream support is around `GET` and `HEAD` requests only possibly?

Anyway this restricts the actually cache storage to `GET` and `HEAD` only whilst still adding the cache headers for a page which might be warranted.

Easy test page component.

```
export const getEdgeProps = async ({ event }) => {
  console.debug(event.request.method);

  return {
    props: {
      method: event.request.method,
    },
  };
};

export default function Index({ method }) {
  return (
    <>
      <h1>Form Post!</h1>
      <h2>Request Method was: {method}!</h2>
      <form method="post">
        <button type="submit" name="test" value="yes">
          Submit it!
        </button>
      </form>
    </>
  );
}


```