### PR TITLE
fix: Handle query string on hard load index page

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -105,7 +105,7 @@ export function RouterProvider({
       events.emit("routeChangeComplete", { asPath: route.asPath, shallow });
     }
 
-    if (initialPath === route.asPath) {
+    if (initialPath === removeQueryString(route.asPath)) {
       return;
     }
 
@@ -275,6 +275,16 @@ export function RouterProvider({
     if (nameEl) {
       nameEl.scrollIntoView();
     }
+  }
+
+  function removeQueryString(path) {
+    const index = path.indexOf('?');
+
+    if (index !== -1) {
+      return path.substring(0, index);
+    }
+
+    return path;
   }
 
   const router = {


### PR DESCRIPTION
It loading an index page with a query string on a hard load the router would still request the props which would fail with a 500.

This fix strips the query string from the check which determines if props are actually required or not.